### PR TITLE
fix(middleware): allow setSource to be synchronous

### DIFF
--- a/src/js/tech/middleware.js
+++ b/src/js/tech/middleware.js
@@ -16,7 +16,7 @@ export function getMiddleware(type) {
 }
 
 export function setSource(player, src, next) {
-  player.setTimeout(() => setSourceHelper(src, middlewares[src.type], next, player), 1);
+  setSourceHelper(src, middlewares[src.type], next, player);
 }
 
 export function setTech(middleware, tech) {


### PR DESCRIPTION
Previously, calls to middleware.setSource always set the source asynchronously.
However, there are common use cases for mobile devices where you need to be able to set
the source synchronously. On mobile browsers, auto-playing videos are stopped, and so are
calls to the HTML5 Video element's play function unless the browser can synchronously
associate that function call with a user-initiated browser event (such as a "click" event).
Mobile browsers currently cannot associate play requests with a user-initiated browser
event if that play request is invoked from an asynchronous callback (setTimeout, Promise,
etc).

For example, consider a page that has a video player and a list of videos with a "play"
button next to each video. When the user clicks a "play" button next to one of the videos,
the click event handler will call `player.src({ src: 'example' })` on the video.js player
instance, and then call `player.play()` immediately after. This works fine on desktop
browsers because the current implementation of the play function waits for the sources to
be set before playing. On mobile browsers, however, playback is blocked because the
browser cannot associate the user's click event with the call to `play()` because the
source-setting process is asynchronous, which causes the play() request to be
asynchronous.

This fix allows the call to `player.src({ src: 'example' })` (and the resulting call to
`middleware.setSource`) to be synchronous, given that there is no middleware that calls
its `next` callback asynchronously. That may not always be the case, but this fix is
focused on supporting the scenario described above in the case where there is no
asynchronous middleware.

Fixes #4765

## Description
Please describe the change as necessary.
If it's a feature or enhancement please be as detailed as possible.
If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
